### PR TITLE
Remove NUL-temrination from cs_base64_{encode,decode} functions

### DIFF
--- a/frozen.c
+++ b/frozen.c
@@ -641,7 +641,6 @@ int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
 
         const char *end_of_format_specifier = "sdfFeEgGlhuIcx.*-0123456789";
         int n = strspn(fmt + 1, end_of_format_specifier);
-        if (n == 0 && fmt[1] == '%') n = 1;
         char *pbuf = buf;
         int need_len, size = sizeof(buf);
         char fmt2[20];
@@ -710,8 +709,6 @@ int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
               break;
             case 'p':
               (void) va_arg(ap, void *);
-              break;
-            case '%':
               break;
             default:
               /* many types are promoted to int */


### PR DESCRIPTION
PUBLISHED_FROM=ac9011b00d12243fa3b6dfe37730a007afb18cf1